### PR TITLE
Use multistage container builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM fedora AS builder
+
+RUN yum install -y golang make
+ENV GOPATH=/go
+RUN mkdir -p /go/src/kubevirt.io/vmctl/cmd/vmctl
+RUN mkdir -p /go/src/kubevirt.io/vendor
+COPY cmd/vmctl/vmctl.go /go/src/kubevirt.io/vmctl/cmd/vmctl/vmctl.go
+COPY vendor /go/src/kubevirt.io/vmctl/vendor/
+
+WORKDIR /go/src/kubevirt.io/vmctl/cmd/vmctl/
+RUN go build vmctl.go
+
+FROM fedora
+
+COPY --from=builder /go/src/kubevirt.io/vmctl/cmd/vmctl/vmctl /vmctl
+
+ENTRYPOINT ["/vmctl"]

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 TAG=quay.io/fabiand/vmctl
 
 ifdef BUILD_NEXT
-build: build-go
+build:
 	buildah bud -t $(TAG) .
 
 run:
@@ -11,8 +11,8 @@ push:
 	echo
 endif
 
-build: build-go
-	docker build -t $(TAG) cmd/vmctl/
+build:
+	docker build -t $(TAG) .
 
 build-go: format
 	cd cmd/vmctl ;\

--- a/cmd/vmctl/Dockerfile
+++ b/cmd/vmctl/Dockerfile
@@ -1,5 +1,0 @@
-FROM fedora
-
-ADD vmctl /
-
-ENTRYPOINT ["/vmctl"]


### PR DESCRIPTION
Change build approach to use multi-stage container builds.

Confirmed working with docker, buildah and podman.

Moved the Dockerfile to the main level of the source tree in order to be able to reference vendor folder.